### PR TITLE
Fix menu only closing when slide left

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -72,7 +72,7 @@
   function touchEnd(event) {
     var endDistance = Math.min(0, movedDistance - startDistance);
     $menu.style.transform = "";
-    if (endDistance < 0) {
+    if (endDistance < 0 && movedDistance !== 0) {
       hideMenu();
     }
   }


### PR DESCRIPTION
Currently the menu is closing even when you touched a bit on it (on mobile), so I fixed that